### PR TITLE
Try to fix Darwin build for test validator

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -23,7 +23,7 @@
           "solana-stake-accounts"
           "solana-tokens"
           # Linker error on Darwin about System framework
-          # "solana-test-validator"
+          "solana-test-validator"
         ];
 
         meta = with pkgs.stdenv; with pkgs.lib; {
@@ -84,6 +84,7 @@
             '';
             LIBCLANG_PATH = "${pkgs.llvmPackages.libclang.lib}/lib";
             LLVM_CONFIG_PATH = "${pkgs.llvm}/bin/llvm-config";
+            NIX_LDFLAGS="-F${pkgs.darwin.apple_sdk.frameworks.System}/Library/Frameworks -framework System $NIX_LDFLAGS";
 
             cargoBuildFlags = builtins.map (binName: "--bin=${binName}") endUserBins;
           };


### PR DESCRIPTION
This fails with 

    = note: ld: framework not found System
            clang-11: error: linker command failed with exit code 1 (use -v to see invocation)
