### PR TITLE
Fix cargo-build-bpf

### DIFF
--- a/bpf_tools_hash.fish
+++ b/bpf_tools_hash.fish
@@ -1,0 +1,9 @@
+#!/usr/bin/env fish
+
+set -l url "https://github.com/solana-labs/bpf-tools/releases/download/v1.12/"
+
+set -l macos_file "solana-bpf-tools-osx.tar.bz2"
+set -l linux_file "solana-bpf-tools-linux.tar.bz2"
+
+echo "macos: " (nix-hash --type sha256 --base32 --flat (curl -LsSo - $url$macos_file | psub))
+echo "linux: " (nix-hash --type sha256 --base32 --flat (curl -LsSo - $url$linux_file | psub))

--- a/flake.lock
+++ b/flake.lock
@@ -1,12 +1,33 @@
 {
   "nodes": {
+    "fenix": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "rust-analyzer-src": "rust-analyzer-src"
+      },
+      "locked": {
+        "lastModified": 1634797872,
+        "narHash": "sha256-RPZt44B5wXueHwFSDaZfV20CmKma5xxuYerIegFyo2U=",
+        "owner": "nix-community",
+        "repo": "fenix",
+        "rev": "1015ddc6b66421217ccd32ed583dabe80da1eccc",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "fenix",
+        "type": "github"
+      }
+    },
     "flake-utils": {
       "locked": {
-        "lastModified": 1631561581,
-        "narHash": "sha256-3VQMV5zvxaVLvqqUrNz3iJelLw30mIVSfZmAaauM3dA=",
+        "lastModified": 1634851050,
+        "narHash": "sha256-N83GlSGPJJdcqhUxSCS/WwW5pksYf3VP1M13cDRTSVA=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "7e5bf3925f6fbdfaf50a2a7ca0be2879c4261d19",
+        "rev": "c91f3de5adaf1de973b797ef7485e441a65b8935",
         "type": "github"
       },
       "original": {
@@ -17,11 +38,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1632025165,
-        "narHash": "sha256-vFHkvmdwbJAFg2d60CQ4fbqpEAUFXR0SO3HRWI4+bXM=",
+        "lastModified": 1633422745,
+        "narHash": "sha256-gA6Ok64nPbkjHk3Oanq4641EeYkjcKhisDF9wBjLxEk=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "a54d2e72e282f2bc68c49f82c735cf664244ec75",
+        "rev": "8e1eab9eae4278c9bb1dcae426848a581943db5a",
         "type": "github"
       },
       "original": {
@@ -33,9 +54,27 @@
     },
     "root": {
       "inputs": {
+        "fenix": "fenix",
         "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs",
         "solanaSrc": "solanaSrc"
+      }
+    },
+    "rust-analyzer-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1634763766,
+        "narHash": "sha256-LI9M1ZxGVjKjVp9QiU2rv44ix70EaP5yCHpg5UdJYDQ=",
+        "owner": "rust-analyzer",
+        "repo": "rust-analyzer",
+        "rev": "6877240fdf597533e2d3349454f62fdc40aaae54",
+        "type": "github"
+      },
+      "original": {
+        "owner": "rust-analyzer",
+        "ref": "nightly",
+        "repo": "rust-analyzer",
+        "type": "github"
       }
     },
     "solanaSrc": {

--- a/flake.lock
+++ b/flake.lock
@@ -8,11 +8,11 @@
         "rust-analyzer-src": "rust-analyzer-src"
       },
       "locked": {
-        "lastModified": 1634797872,
-        "narHash": "sha256-RPZt44B5wXueHwFSDaZfV20CmKma5xxuYerIegFyo2U=",
+        "lastModified": 1635601111,
+        "narHash": "sha256-+UWu41BL713+zPBA1YunLto8uPLvBWqMqb/HrK0Glug=",
         "owner": "nix-community",
         "repo": "fenix",
-        "rev": "1015ddc6b66421217ccd32ed583dabe80da1eccc",
+        "rev": "1c1a6cd1d091d11ba2ccda42e758a08e47dd0d59",
         "type": "github"
       },
       "original": {
@@ -38,11 +38,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1633422745,
-        "narHash": "sha256-gA6Ok64nPbkjHk3Oanq4641EeYkjcKhisDF9wBjLxEk=",
+        "lastModified": 1635544589,
+        "narHash": "sha256-v6PTartv2TlsntrCz9YFIdRU6ihPKFvrEfKK2BSFOoE=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "8e1eab9eae4278c9bb1dcae426848a581943db5a",
+        "rev": "47b36ad103aeff17f9be6fb7b4847d63d53f227a",
         "type": "github"
       },
       "original": {
@@ -63,11 +63,11 @@
     "rust-analyzer-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1634763766,
-        "narHash": "sha256-LI9M1ZxGVjKjVp9QiU2rv44ix70EaP5yCHpg5UdJYDQ=",
+        "lastModified": 1635274542,
+        "narHash": "sha256-Cew1/WUozM3jalItPuj4cNN8GIFMvCaJ1KXoj6wrHwE=",
         "owner": "rust-analyzer",
         "repo": "rust-analyzer",
-        "rev": "6877240fdf597533e2d3349454f62fdc40aaae54",
+        "rev": "dd43f3f2d13a32199828e758ddf13176df1f17f9",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -102,6 +102,8 @@
             cargoBuildFlags = builtins.map (binName: "--bin=${binName}") endUserBins;
           };
 
+        fenixSystem = if system == "aarch64-darwin" then "x86_64-darwin" else "x86_64-linux";
+
       in
       rec {
         packages = flake-utils.lib.flattenTree {
@@ -112,7 +114,7 @@
         defaultApp = apps.solana;
         devShell = pkgs.mkShell {
           buildInputs = with pkgs; [
-            (fenix.packages.x86_64-darwin.complete.withComponents [
+            (fenix.packages."${fenixSystem}".complete.withComponents [
               "cargo"
               "clippy"
               "rust-src"

--- a/patch
+++ b/patch
@@ -1,0 +1,19 @@
+diff --git a/sdk/cargo-build-bpf/src/main.rs b/sdk/cargo-build-bpf/src/main.rs
+index a86fb167a..0b2845360 100644
+--- a/sdk/cargo-build-bpf/src/main.rs
++++ b/sdk/cargo-build-bpf/src/main.rs
+@@ -430,14 +430,6 @@ fn build_bpf_package(config: &Config, target_directory: &Path, package: &cargo_m
+     } else {
+         "solana-bpf-tools-linux.tar.bz2"
+     };
+-    install_if_missing(
+-        config,
+-        "bpf-tools",
+-        "v1.12",
+-        "https://github.com/solana-labs/bpf-tools/releases/download",
+-        bpf_tools_download_file_name,
+-    )
+-    .expect("Failed to install bpf-tools");
+     link_bpf_toolchain(config);
+ 
+     let llvm_bin = config


### PR DESCRIPTION
With this commit it should be possible to run "cargo-build-bpf". There's
also a shell script of the same name as the Rust executable, which is:

https://github.com/solana-labs/solana/blob/master/cargo-build-bpf

Not sure how the two are related, but at least you should be able to use
either of the two commands with the CLI flags shown in the shell script.

Changes:
- Add fenix overlay to have Rust locally available
- keep the BPF sdk in the output folder